### PR TITLE
payload state inside authorizationDetails

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -264,11 +264,11 @@ const ChargeConnectionsResponseHandler = {
             return error.handleErrors( handlerInput );
         } 
 
-        const authorizationStatusState = connectionResponsePayload.authorizationDetails.state;
-        
+        const authorizationStatusState = connectionResponsePayload.authorizationDetails.authorizationStatus.state;
+
         // Authorization is declined, tell the customer their order was not placed
         if( authorizationStatusState === 'Declined' ) {
-            const authorizationStatusReasonCode = connectionResponsePayload.authorizationDetails.reasonCode;
+            const authorizationStatusReasonCode = connectionResponsePayload.authorizationDetails.authorizationStatus.reasonCode;
 
             return error.handleAuthorizationDeclines( authorizationStatusReasonCode, handlerInput );
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Upon certifying, the team noted the decline was not properly handled. That was due to the object value actually being undefined.  So the success code works (!== "Declined") but the declined status did not.  This change sets the variable to the proper object value nested deeper within the payload response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
